### PR TITLE
Refactor, squash bugs, improve docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant/
 config.rb
+ssl/

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 **micro-kube** is the fastest way to start a fully-functional, single-node [Kubernetes](http://kubernetes.io/) cluster using [CoreOS](https://coreos.com/) on [Vagrant](https://www.vagrantup.com/).
 
+micro-kube attempts to differentiate itself from other similar projects by being maximally useful right out-of-the-box.  See the [roadmap](#roadmap) for further details.
+
 ## Getting started
 
-Getting started with micro-kube is incredibly easy as long as you have Vagrant already installed and functioning properly.
+Getting started with micro-kube on a Mac or Linux machine is incredibly easy as long as you have Vagrant already installed and functioning properly.
 
 Just clone this repository and `vagrant up`!
 
@@ -16,26 +18,46 @@ $ vagrant up
 
 Allow a couple minutes after starting for all services to become fully function.  Wait time may vary with the speed of your internet connection.
 
-The Kubernetes API will be available at [http://localhost:8080](http://localhost:8080)
+The Kubernetes API will be available at http://172.17.8.100:8080 and https://172.17.8.100:5443
 
-The Kubernetes UI will be available at [http://localhost:8080/ui](http://localhost:8080/ui)
+The Kubernetes UI (a dashboard application) will be available at http://172.17.8.100:8080/ui
+
+## Installing kubectl
+
+If this is your first time exploring Kubernetes and you don't already have the __kubectl__ tool installed, follow the installation directions [here](http://kubernetes.io/v1.0/docs/getting-started-guides/aws/kubectl.html).
 
 ## Configuring kubectl
 
-The following configuration will prepare your local kubectl tool to interact with micro-kube:
+micro-kube exposes both secure and insecure API endpoints.  As such, either of the following configurations will adequately prepare your kubectl tool to interact with micro-kube.
+
+__Insecure:__
+
+From the micro-kube directory:
 
 ```
-$ kubectl config set-cluster micro-kube --server=http://localhost:8080
-$ kubectl config set-context micro-kube --cluster=micro-kube
-$ kubectl config use-context micro-kube
+$ kubectl config set-cluster micro-kube-insecure --server=http://172.17.8.100:8080
+$ kubectl config set-context micro-kube-insecure --cluster=micro-kube-insecure
+$ kubectl config use-context micro-kube-insecure
+```
 
+__Secure:__
+
+From the micro-kube directory:
+
+```
+$ kubectl config set-cluster micro-kube-secure --server=https://172.17.8.100:6443 --certificate-authority=$(pwd)/ssl/ca.pem
+$ kubectl config set-credentials micro-kube-admin --client-certificate=$(pwd)/ssl/admin.pem --client-key=$(pwd)/ssl/admin-key.pem
+$ kubectl config set-context micro-kube-secure --cluster=micro-kube-secure --user=micro-kube-admin
+$ kubectl config use-context micro-kube-secure
 ```
 
 ## Configuration options
 
 micro-kube does not expose many configuration options.  The few available can be tweaked by providing a `config.rb` file.
 
-micro-kube comes with sample configuration which also contains documentation for each option.  You can create your own `config.rb` by copying and modifying this sample:
+micro-kube comes with sample configuration which also contains documentation for each option.  You can create your own `config.rb` by copying and modifying this sample.
+
+From the micro-kube directory:
 
 ```
 $ cp config.rb.sample config.rb
@@ -43,31 +65,77 @@ $ cp config.rb.sample config.rb
 
 ## How it works
 
-micro-kube's `Vagrantfile` uses cloud-config found in the file `Userdata`.  This includes various scripts and systemd units required to download and start all of the following:
+micro-kube's `Vagrantfile` uses cloud-config found in the file `user-data`.  This includes various scripts and systemd units required to download and start just one binary:
+
+* kubelet
+
+A kubelet is a Kubernetes agent that typically runs on every node-- of course micro-kube has just one node.  It is able to start pods and their constituent containers at the behest of the scheduler, but it can _also_ be configured to start pods whose manifests are stored locally on disk.  micro-kube uses that strategy to compel the kubelet to launch the rest of the Kubernetes components in pods within a `kube-system` namespace.  These include:
 
 * kube-apiserver
 * kube-controller-manager
 * kube-scheduler
-* kube-kubelet
 * kube-proxy
-* Two Kubernetes addons:
-  * kube-ui
-  * kube-dns (SkyDNS)
 
-To troubleshoot individual components:
+micro-kube also starts two Kubernetes add-ons by using the kubectl tool directly to create requisite replication controllers and services _after_ the containerized kube-apiserver becomes available.  These add-ons include:
 
-Check status:
+* [kube-ui](https://github.com/kubernetes/kube-ui)
+* [kube-dns](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns)
+
+## Troubleshooting
+
+Although this should be a rare event, if micro-kube should happen to not function as expected, one can begin to troubleshoot by checking the status of various Kubernetes components and inspecting their logs.
+
+### Troubleshooting the kubelet
+
+The kubelet is the one kubernetes component that is started from a binary.  To check its status, one must first ssh to the micro-kube VM.
+
+From the micro-kube directory:
 
 ```
 $ vagrant ssh
-$ sudo systemctl status <component name>
 ```
 
-View logs:
+To check status:
 
 ```
-$ sudo journalctl -f <component name>
+$ sudo systemctl status kubelet
 ```
+
+To view logs:
+
+```
+$ sudo journalctl -f kubelet
+```
+
+### Troubleshooting other components
+
+In micro-kube, all other components _of_ Kubernetes are managed _by_ Kubernetes.  To list the pods that comprise the `kube-system` namespace:
+
+```
+$ kubectl get pods --namespace=kube-system
+```
+
+You can view logs for any pod in the `kube-system` namespace like so:
+
+```
+$ kubectl logs <pod name> --namespace=kube-system
+```
+
+## Known issues
+
+* Kubernetes services are exposed using virtual IPs that are meaningless outside of the flannel-based overlay network that micro-kube uses internally.  As such, it's not presently possible to access applications you have deployed on micro-kube via an agent on the host machine (e.g. a web browser).  This is presently micro-kube's most damning limitation, but it is soon to be addressed by the [roadmap](#roadmap).
+
+* Although micro-kube exposes both secure and insecure API endpoints, the kube-ui addon is accessible _only_ via an insecure port.  Two factors contribute to this:
+  1. Kubernetes exposes the kube-ui by proxying it through an API endpoint.  While this may seem a questionable design decision upstream, it allows kube-ui to easily overcome the issue of service endpoints not being addressable from outside Kubernetes' virtual network.  (See previous issue.)
+  2. Use of the secure API endpoint requires mutual authentication, which a web browser, for instance, will not accommodate without additional configuration.
+
+* micro-kube does not work on Windows.
+
+## <a name="roadmap"></a>Roadmap
+
+Since micro-kube attempts to differentiate itself from similar projects by being both maximally simple and maximally useful, here are some features we seek to implement in the near future:
+
+* __Service exposition:__ Kubernetes services are exposed using virtual IPs that are meaningless outside of the flannel-based overlay network that micro-kube uses internally.  As such, it's not presently possible to access applications you have deployed on micro-kube via an agent on the host machine (i.e. a browser on your laptop).  We aim to address this in the next release by providing a simple, third-party or custom Kubernetes add-on that will route all incoming HTTP traffic on the micro-kube VM to the appropriate service endpoint.
 
 ## Contributing
 

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -14,9 +14,3 @@
 # $vm_memory = 1024
 # $vm_cpus = 1
 # $ip = '172.17.8.100'
-
-# Enable port forwarding from guest to host machine.
-# Syntax is: { 80 => 8080 }
-# Auto correction is enabled by default.
-
-# $forwarded_ports = { 8080 => 8080}

--- a/init-ssl
+++ b/init-ssl
@@ -1,0 +1,65 @@
+#!/bin/bash -e
+
+# define location of openssl binary manually since running this
+# script under Vagrant fails on some systems without it
+OPENSSL=/usr/bin/openssl
+
+function usage {
+    echo "USAGE: $0 <output-dir> [SAN,SAN,SAN]"
+    echo "  example: $0 ./ssl IP.1=127.0.0.1,IP.2=10.0.0.1"
+}
+
+if [ -z "$1" ]; then
+    usage
+    exit 1
+fi
+
+if [ ! -d $1 ]; then
+    echo "ERROR: output directory does not exist: $1"
+    exit 1
+fi
+
+OUTDIR=$1
+SANS=$2
+
+OUTFILE_CONTROLLER="$OUTDIR/controller.tar"
+
+CNF_TEMPLATE="
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = kubernetes
+DNS.2 = kubernetes.default
+"
+
+echo "Generating SSL artifacts in: $OUTDIR"
+
+# Add SANs to openssl config
+echo "$CNF_TEMPLATE$(echo $SANS | tr ',' '\n')" > $OUTDIR/apiserver-req.cnf
+
+# establish cluster CA and self-sign a cert
+$OPENSSL genrsa -out $OUTDIR/ca-key.pem 2048
+$OPENSSL req -x509 -new -nodes -key $OUTDIR/ca-key.pem -days 10000 -out $OUTDIR/ca.pem -subj "/CN=kube-ca"
+
+# create apiserver key and signed cert
+$OPENSSL genrsa -out $OUTDIR/apiserver-key.pem 2048
+$OPENSSL req -new -key $OUTDIR/apiserver-key.pem -out $OUTDIR/apiserver.csr -subj "/CN=kube-apiserver" -config $OUTDIR/apiserver-req.cnf
+$OPENSSL x509 -req -in $OUTDIR/apiserver.csr -CA $OUTDIR/ca.pem -CAkey $OUTDIR/ca-key.pem -CAcreateserial -out $OUTDIR/apiserver.pem -days 365 -extensions v3_req -extfile $OUTDIR/apiserver-req.cnf
+
+# create admin key and signed cert
+$OPENSSL genrsa -out $OUTDIR/admin-key.pem 2048
+$OPENSSL req -new -key $OUTDIR/admin-key.pem -out $OUTDIR/admin.csr -subj "/CN=kube-admin"
+$OPENSSL x509 -req -in $OUTDIR/admin.csr -CA $OUTDIR/ca.pem -CAkey $OUTDIR/ca-key.pem -CAcreateserial -out $OUTDIR/admin.pem -days 365
+
+tar -cf $OUTFILE_CONTROLLER -C $OUTDIR/ ca.pem apiserver.pem apiserver-key.pem
+
+echo "Bundled controller SSL artifacts into $OUTFILE_CONTROLLER"

--- a/user-data
+++ b/user-data
@@ -28,7 +28,7 @@ coreos:
       - name: 50-network-config.conf
         content: |
           [Service]
-          ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16" }'
+          ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ "Network": "10.2.0.0/16" }'
       command: start
 
     - name: docker-tcp.socket
@@ -46,52 +46,7 @@ coreos:
         [Install]
         WantedBy=sockets.target
 
-    - name: kube-apiserver.service
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Kubernetes API Server
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-
-        [Service]
-        EnvironmentFile=/etc/environment
-        ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kube-apiserver"
-        ExecStart=/opt/bin/kube-apiserver \
-          --allow_privileged=true \
-          --insecure_bind_address=0.0.0.0 \
-          --insecure_port=8080 \
-          --kubelet_https=true \
-          --secure_port=6443 \
-          --service-cluster-ip-range=10.100.0.0/16 \
-          --etcd_servers=http://127.0.0.1:2379 \
-          --public_address_override=127.0.0.1 \
-          --logtostderr=true \
-          --runtime_config=api/v1
-
-        Restart=always
-        RestartSec=10
-
-    - name: kube-controller-manager.service
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Kubernetes Controller Manager
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-
-        [Service]
-        EnvironmentFile=/etc/environment
-        ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kube-controller-manager"
-        ExecStartPre=/opt/bin/wupiao 127.0.0.1:8080
-        ExecStart=/opt/bin/kube-controller-manager \
-          --master=127.0.0.1:8080 \
-          --logtostderr=true
-
-        Restart=always
-        RestartSec=10
-
-    - name: kube-kubelet.service
+    - name: kubelet.service
       command: start
       enable: true
       content: |
@@ -101,19 +56,15 @@ coreos:
 
         [Service]
         EnvironmentFile=/etc/environment
-        ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kubelet"
-        ExecStartPre=/opt/bin/wupiao 127.0.0.1:8080
+        ExecStartPre=/opt/bin/download-k8s-binary kubelet
         ExecStart=/opt/bin/kubelet \
-          --address=0.0.0.0 \
-          --port=10250 \
+          --config=/etc/micro-kube/system \
+          --allow-privileged=true \
           --hostname_override=${COREOS_PRIVATE_IPV4} \
           --register-node=true \
-          --container_runtime=docker \
           --api_servers=http://127.0.0.1:8080 \
-          --allow_privileged=true \
-          --cluster_dns=10.100.0.10 \
+          --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local \
-          --logtostderr=true \
           --cadvisor_port=4194 \
           --healthz_bind_address=0.0.0.0 \
           --healthz_port=10248
@@ -121,43 +72,8 @@ coreos:
         Restart=always
         RestartSec=10
 
-    - name: kube-proxy.service
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Kubernetes Proxy
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-
-        [Service]
-        EnvironmentFile=/etc/environment
-        ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kube-proxy"
-        ExecStartPre=/opt/bin/wupiao 127.0.0.1:8080
-        ExecStart=/opt/bin/kube-proxy \
-          --master=http://127.0.0.1:8080 \
-          --logtostderr=true
-
-        Restart=always
-        RestartSec=10
-
-    - name: kube-scheduler.service
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Kubernetes Scheduler
-        Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-
-        [Service]
-        EnvironmentFile=/etc/environment
-        ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kube-scheduler"
-        ExecStartPre=/opt/bin/wupiao 127.0.0.1:8080
-        ExecStart=/opt/bin/kube-scheduler \
-          --master=127.0.0.1:8080 \
-          --logtostderr=true
-
-        Restart=always
-        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
 
     - name: kube-ui.service
       command: start
@@ -173,8 +89,8 @@ coreos:
         ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kubectl"
         ExecStartPre=/opt/bin/wupiao 127.0.0.1:8080
         ExecStart=/bin/bash -c "/opt/bin/kubectl describe rc kube-ui --namespace=kube-system >/dev/null 2>&1 || \
-          /opt/bin/kubectl create -f /var/lib/micro-kube/kube-ui-rc.yaml && \
-          /opt/bin/kubectl create -f /var/lib/micro-kube/kube-ui-svc.yaml"
+          /opt/bin/kubectl create -f /etc/micro-kube/addons/kube-ui-rc.yaml && \
+          /opt/bin/kubectl create -f /etc/micro-kube/addons/kube-ui-svc.yaml"
 
     - name: kube-dns.service
       command: start
@@ -190,8 +106,8 @@ coreos:
         ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kubectl"
         ExecStartPre=/opt/bin/wupiao 127.0.0.1:8080
         ExecStart=/bin/bash -c "/opt/bin/kubectl describe rc kube-dns --namespace=kube-system >/dev/null 2>&1 || \
-          /opt/bin/kubectl create -f /var/lib/micro-kube/kube-dns-rc.yaml && \
-          /opt/bin/kubectl create -f /var/lib/micro-kube/kube-dns-svc.yaml"
+          /opt/bin/kubectl create -f /etc/micro-kube/addons/kube-dns-rc.yaml && \
+          /opt/bin/kubectl create -f /etc/micro-kube/addons/kube-dns-svc.yaml"
 
 write_files:
 
@@ -226,7 +142,150 @@ write_files:
         done;
       exit $?
 
-  - path: /var/lib/micro-kube/kube-ui-rc.yaml
+  - path: /etc/micro-kube/system/kube-apiserver.yaml
+    permission: '0644'
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: kube-apiserver
+        namespace: kube-system
+      spec:
+        hostNetwork: true
+        containers:
+        - name: kube-apiserver
+          image: gcr.io/google_containers/hyperkube:v1.0.6
+          command:
+          - /hyperkube
+          - apiserver
+          - --bind-address=0.0.0.0
+          - --insecure-bind-address=0.0.0.0
+          - --etcd_servers=http://127.0.0.1:2379
+          - --allow-privileged=true
+          - --service-cluster-ip-range=10.3.0.0/24
+          - --secure-port=6443
+          - --insecure-port=8080
+          - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
+          - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+          - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+          - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+          ports:
+          - containerPort: 6443
+            hostPort: 6443
+            name: https
+          - containerPort: 8080
+            hostPort: 8080
+            name: local
+          volumeMounts:
+          - mountPath: /etc/kubernetes/ssl
+            name: ssl-certs-micro-kube
+            readOnly: true
+          - mountPath: /etc/ssl/certs
+            name: ssl-certs-host
+            readOnly: true
+        volumes:
+        - hostPath:
+            path: /etc/micro-kube/ssl
+          name: ssl-certs-micro-kube
+        - hostPath:
+            path: /usr/share/ca-certificates
+          name: ssl-certs-host
+
+  - path: /etc/micro-kube/system/kube-controller-manager.yaml
+    permission: '0644'
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: kube-controller-manager
+        namespace: kube-system
+      spec:
+        hostNetwork: true
+        containers:
+        - name: kube-controller-manager
+          image: gcr.io/google_containers/hyperkube:v1.0.6
+          command:
+          - /hyperkube
+          - controller-manager
+          - --master=http://127.0.0.1:8080
+          - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+          - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /healthz
+              port: 10252
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          volumeMounts:
+          - mountPath: /etc/kubernetes/ssl
+            name: ssl-certs-micro-kube
+            readOnly: true
+          - mountPath: /etc/ssl/certs
+            name: ssl-certs-host
+            readOnly: true
+        volumes:
+        - hostPath:
+            path: /etc/micro-kube/ssl
+          name: ssl-certs-micro-kube
+        - hostPath:
+            path: /usr/share/ca-certificates
+          name: ssl-certs-host
+
+  - path: /etc/micro-kube/system/kube-proxy.yaml
+    permission: '0644'
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: kube-proxy
+        namespace: kube-system
+      spec:
+        hostNetwork: true
+        containers:
+        - name: kube-proxy
+          image: gcr.io/google_containers/hyperkube:v1.0.6
+          command:
+          - /hyperkube
+          - proxy
+          - --master=http://127.0.0.1:8080
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /etc/ssl/certs
+            name: ssl-certs-host
+            readOnly: true
+        volumes:
+        - hostPath:
+            path: /usr/share/ca-certificates
+          name: ssl-certs-host
+
+  - path: /etc/micro-kube/system/kube-scheduler.yaml
+    permission: '0644'
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: kube-scheduler
+        namespace: kube-system
+      spec:
+        hostNetwork: true
+        containers:
+        - name: kube-scheduler
+          image: gcr.io/google_containers/hyperkube:v1.0.6
+          command:
+          - /hyperkube
+          - scheduler
+          - --master=http://127.0.0.1:8080
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /healthz
+              port: 10251
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+
+  - path: /etc/micro-kube/addons/kube-ui-rc.yaml
     permission: '0644'
     content: |
       apiVersion: v1
@@ -260,7 +319,7 @@ write_files:
               ports:
               - containerPort: 8080
 
-  - path: /var/lib/micro-kube/kube-ui-svc.yaml
+  - path: /etc/micro-kube/addons/kube-ui-svc.yaml
     permission: '0644'
     content: |
       apiVersion: v1
@@ -279,7 +338,7 @@ write_files:
         - port: 80
           targetPort: 8080
 
-  - path: /var/lib/micro-kube/kube-dns-rc.yaml
+  - path: /etc/micro-kube/addons/kube-dns-rc.yaml
     permission: '0644'
     content: |
       apiVersion: v1
@@ -326,7 +385,7 @@ write_files:
                   memory: 50Mi
               args:
               # command = "/kube2sky"
-              - -kube_master_url=http://172.19.17.99:8080
+              - -kube_master_url=http://172.17.8.100:8080
               - -domain=cluster.local
             - name: skydns
               image: gcr.io/google_containers/skydns:2015-03-11-001
@@ -349,7 +408,7 @@ write_files:
                 protocol: TCP
             dnsPolicy: Default  # Don't use cluster DNS.
 
-  - path: /var/lib/micro-kube/kube-dns-svc.yaml
+  - path: /etc/micro-kube/addons/kube-dns-svc.yaml
     permission: '0644'
     content: |
       apiVersion: v1
@@ -364,7 +423,7 @@ write_files:
       spec:
         selector:
           k8s-app: kube-dns
-        clusterIP: 10.100.0.10
+        clusterIP: 10.3.0.10
         ports:
         - name: dns
           port: 53


### PR DESCRIPTION
This is a major refactor. The kubelet is now the only
Kubernetes component that is downloaded and started as
a binary. The kubelet is then used to bootstrap all
other kubernetes components.  Bugs have been fixed in
the kube-dns manifest.  Docs have been significantly
updated to reflect things that changed in the refactor
and to also include a list of known issues and a
roadmap.