### PR TITLE
Add a test task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+SERVER := 172.17.8.100:8080
+
+check-vagrant:
+	@if [ -z $$(which vagrant) ]; then \
+		echo "Missing \`vagrant\`, which is required for development"; \
+		exit 1; \
+	fi
+
+check-kubectl:
+	@if [ -z $$(which kubectl) ]; then \
+		echo "Missing \`kubectl\`, which is required for development"; \
+		exit 1; \
+	fi
+
+up: check-vagrant
+	vagrant up
+
+destroy: check-vagrant
+	vagrant destroy -f
+
+config-kubectl: check-kubectl
+	kubectl config set-cluster micro-kube-insecure --server=http://${SERVER}
+	kubectl config set-context micro-kube-insecure --cluster=micro-kube-insecure
+	kubectl config use-context micro-kube-insecure
+
+test: check-vagrant check-kubectl up config-kubectl
+	@./_scripts/wupiao.sh ${SERVER} 300 || ($(MAKE) destroy && exit 1)
+	@$(MAKE) destroy

--- a/_scripts/wupiao.sh
+++ b/_scripts/wupiao.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# [w]ait [u]ntil [p]ort [i]s [a]ctually [o]pen
+# Usage: ./wupiao.sh server:host tries
+
+set -e
+
+[ -n "$1" ]
+[ -n "$2" ]
+
+function echo_red {
+  echo -e "\033[0;31m$1\033[0m"
+}
+
+ATTEMPTS=$2
+SLEEPTIME=1
+COUNTER=1
+
+until curl -o /dev/null -sIf http://${1}; do
+  if [ $COUNTER -gt $ATTEMPTS ]; then
+    echo_red "Timed out waiting for ${1}, giving up"
+    exit 1
+  fi
+  sleep $SLEEPTIME
+  let COUNTER=COUNTER+1
+done;


### PR DESCRIPTION
This PR provides a _simple_ (i.e. naive) test of micro-kube by simply doing `vagrant up` and then asserting that port 8080 on the VM eventually becomes available.  There are probably tons of failure cases that won't be detected by this (for instance, API comes up, but UI does not), but this is a nice start.

Longer term, it would be nice to integrate these sort of tests into a CI pipeline, _however_ hosted CI systems like Travis do not currently appear to play well with Vagrant.